### PR TITLE
feat: fix boos lastmodifytime from job item detail iframe

### DIFF
--- a/src/commonRender.js
+++ b/src/commonRender.js
@@ -13,34 +13,50 @@ export function renderTimeTag(divElement, lastModifyTime, brandName) {
     timeHumanReadable = "【" + "未找到更新时间" + "】";
     timeText = timeHumanReadable;
   }
-  var offsetTimeDay;
-  if (lastModifyTime) {
-    offsetTimeDay = dayjs().diff(dayjs(lastModifyTime), "day");
-  } else {
-    lastModifyTime = -1;
-  }
+  var text = timeText;
+  text += getCompanyInfoText(brandName);
+  divElement.style = getRenderTimeStyle(lastModifyTime);
+  divElement.innerHTML = text;
+}
+
+export function renderTimeLoadingTag(divElement, brandName) {
+  var timeText = "【正查找更新时间⌛︎】";
+  var text = timeText;
+  text += getCompanyInfoText(brandName);
+  divElement.style = getRenderTimeStyle();
+  divElement.innerHTML = text;
+}
+
+function getCompanyInfoText(brandName) {
+  var text = "";
   const isOutsourceBrand = isOutsource(brandName);
   const isTrainingBrand = isTraining(brandName);
-  var text = timeText;
-  var style =
-    "color:white;font-size:12px;background-color: " +
-    getTimeColorByoffsetTimeDay(offsetTimeDay) +
-    ";";
   if (isOutsourceBrand) {
     text += "【疑似外包公司】";
-    divElement.classList.add("__is_outsourcing_or_training");
   }
   if (isTrainingBrand) {
     text += "【疑似培训机构】";
-    divElement.classList.add("__is_outsourcing_or_training");
   }
   if (isOutsourceBrand || isTrainingBrand) {
     text += "⛅";
   } else {
     text += "☀";
   }
-  divElement.style = style;
-  divElement.innerHTML = text;
+  return text;
+}
+
+function getRenderTimeStyle(lastModifyTime) {
+  var offsetTimeDay;
+  if (lastModifyTime) {
+    offsetTimeDay = dayjs().diff(dayjs(lastModifyTime), "day");
+  } else {
+    lastModifyTime = -1;
+  }
+  return (
+    "color:white;font-size:12px;background-color: " +
+    getTimeColorByoffsetTimeDay(offsetTimeDay) +
+    ";"
+  );
 }
 
 function getTimeColorByoffsetTimeDay(offsetTimeDay) {

--- a/src/plantforms/boss/index.js
+++ b/src/plantforms/boss/index.js
@@ -2,6 +2,7 @@ import {
   renderTimeTag,
   setupSortJobItem,
   renderSortJobItem,
+  renderTimeLoadingTag,
 } from "../../commonRender";
 import onlineFilter from "./onlineFilter";
 
@@ -57,12 +58,14 @@ function mutationContainer() {
 function parseBossData(list, getListItem) {
   const urlList = [];
   list.forEach((item) => {
-    const { itemId } = item;
+    const { itemId, brandName } = item;
     const dom = getListItem(itemId);
     const jobItemDetailUrl = dom.childNodes[0].childNodes[0].href;
     const url = new URL(jobItemDetailUrl);
     var pureJobItemDetailUrl = url.origin + url.pathname;
     urlList.push(pureJobItemDetailUrl);
+    let loadingLastModifyTimeTag = createLoadingDOM(brandName);
+    dom.appendChild(loadingLastModifyTimeTag);
   });
   let promiseList = [];
   urlList.forEach((url) => {
@@ -102,10 +105,8 @@ function parseBossData(list, getListItem) {
     promiseList.push(promise);
   });
   const lastModifyTimeList = [];
-  console.log("loading job item lastModifyTime start");
   Promise.allSettled(promiseList)
     .then((textList) => {
-      console.log("loading job item lastModifyTime end");
       textList.forEach((item) => {
         const regxMatchArrayResult = item.value.match(
           '<p class="gray">更新于：.*</p>'
@@ -128,10 +129,10 @@ function parseBossData(list, getListItem) {
         let tag = createDOM(lastModifyTime, brandName);
         dom.appendChild(tag);
       });
+      hiddenLoadingDOM();
       renderSortJobItem(list, getListItem);
     })
     .catch((error) => {
-      console.log("loading job item lastModifyTime end");
       console.log(error);
       list.forEach((item) => {
         const { itemId, lastModifyTime, brandName } = item;
@@ -139,6 +140,7 @@ function parseBossData(list, getListItem) {
         let tag = createDOM(lastModifyTime, brandName);
         dom.appendChild(tag);
       });
+      hiddenLoadingDOM();
     });
 }
 
@@ -152,4 +154,21 @@ function createDOM(lastModifyTime, brandName) {
   div.classList.add("__boss_time_tag");
   renderTimeTag(div, lastModifyTime, brandName);
   return div;
+}
+
+function createLoadingDOM(brandName) {
+  const div = document.createElement("div");
+  div.classList.add("__boss_time_tag");
+  div.classList.add("__loading_tag");
+  renderTimeLoadingTag(div, brandName);
+  return div;
+}
+
+function hiddenLoadingDOM() {
+  var loadingTagList = document.querySelectorAll(".__loading_tag");
+  if (loadingTagList) {
+    loadingTagList.forEach((item) => {
+      item.style = "visibility: hidden;";
+    });
+  }
 }

--- a/src/plantforms/boss/index.js
+++ b/src/plantforms/boss/index.js
@@ -1,76 +1,155 @@
-import { renderTimeTag,setupSortJobItem,renderSortJobItem } from "../../commonRender";
-import onlineFilter from './onlineFilter';
+import {
+  renderTimeTag,
+  setupSortJobItem,
+  renderSortJobItem,
+} from "../../commonRender";
+import onlineFilter from "./onlineFilter";
 
 export function getBossData(responseText) {
-    try {
-        const data = JSON.parse(responseText);
-        mutationContainer().then((node) => {
-            setupSortJobItem(node);
-            parseBossData(data?.zpData?.jobList || [], getListByNode(node));
-            onlineFilter();
-        })
-        return 
-    } catch(err) {
-        console.error('解析 JSON 失败', err);
-    }
+  try {
+    const data = JSON.parse(responseText);
+    mutationContainer().then((node) => {
+      setupSortJobItem(node);
+      parseBossData(data?.zpData?.jobList || [], getListByNode(node));
+      onlineFilter();
+    });
+    return;
+  } catch (err) {
+    console.error("解析 JSON 失败", err);
+  }
 }
 
 // 获取职位列表节点
 function getListByNode(node) {
-    return function getListItem(itemId) {
-        return node.querySelector(`[ka="search_list_${itemId}"]`);
-    }
+  return function getListItem(itemId) {
+    return node.querySelector(`[ka="search_list_${itemId}"]`);
+  };
 }
 
-
 // 监听 search-job-result 节点，判断职位列表是否被挂载
-function mutationContainer () {
-   return new Promise((resolve, reject) => {
-        const dom = document.querySelector('.search-job-result');
-        const observer = new MutationObserver(function(childList, obs) {
-            (childList || []).forEach(item => {
-                const {
-                    addedNodes
-                } = item;
-                if(addedNodes && addedNodes.length > 0)  {
-                    addedNodes.forEach(node => {
-                        const {
-                            className,
-                        } = node;
-                        if(className === 'job-list-box') {
-                            observer.disconnect();
-                            resolve(node);
-                        }
-                    })
-                } 
-            });
-            return reject('未找到职位列表');
+function mutationContainer() {
+  return new Promise((resolve, reject) => {
+    const dom = document.querySelector(".search-job-result");
+    const observer = new MutationObserver(function (childList, obs) {
+      (childList || []).forEach((item) => {
+        const { addedNodes } = item;
+        if (addedNodes && addedNodes.length > 0) {
+          addedNodes.forEach((node) => {
+            const { className } = node;
+            if (className === "job-list-box") {
+              observer.disconnect();
+              resolve(node);
+            }
+          });
+        }
+      });
+      return reject("未找到职位列表");
+    });
 
-        })
-
-        observer.observe(dom, {
-            childList: true,
-            subtree: false
-        })
-   })
+    observer.observe(dom, {
+      childList: true,
+      subtree: false,
+    });
+  });
 }
 
 // 解析数据，插入时间标签
 function parseBossData(list, getListItem) {
-    list.forEach(item => {
-        const {
-            itemId, lastModifyTime, brandName
-        }  = item;
-        const dom = getListItem(itemId);
-        let tag = createDOM(lastModifyTime,brandName); 
-        dom.appendChild(tag);
+  const urlList = [];
+  list.forEach((item) => {
+    const { itemId } = item;
+    const dom = getListItem(itemId);
+    const jobItemDetailUrl = dom.childNodes[0].childNodes[0].href;
+    const url = new URL(jobItemDetailUrl);
+    var pureJobItemDetailUrl = url.origin + url.pathname;
+    urlList.push(pureJobItemDetailUrl);
+  });
+  let promiseList = [];
+  urlList.forEach((url) => {
+    const promise = new Promise((resolve, reject) => {
+      const fetchJobItemDetailIframe = document.createElement("iframe");
+      fetchJobItemDetailIframe.setAttribute("src", url);
+      fetchJobItemDetailIframe.style.width = "0px";
+      fetchJobItemDetailIframe.style.height = "0px";
+      fetchJobItemDetailIframe.addEventListener("load", (event) => {
+        const text =
+          fetchJobItemDetailIframe.contentWindow.document.body.innerHTML;
+        if (isExistsLastModifyTime(text)) {
+          resolve(text);
+          document.body.removeChild(fetchJobItemDetailIframe);
+        } else {
+          fetchJobItemDetailIframe.contentWindow.addEventListener(
+            "hashchange",
+            function () {
+              const text =
+                fetchJobItemDetailIframe.contentWindow.document.body.innerHTML;
+              if (isExistsLastModifyTime(text)) {
+                resolve(text);
+                document.body.removeChild(fetchJobItemDetailIframe);
+              } else {
+                //skip
+              }
+            }
+          );
+        }
+      });
+      fetchJobItemDetailIframe.addEventListener("error", (event) => {
+        resolve(fetchJobItemDetailIframe.contentWindow.document.body.innerHTML);
+        document.body.removeChild(fetchJobItemDetailIframe);
+      });
+      document.body.appendChild(fetchJobItemDetailIframe);
     });
-    renderSortJobItem(list, getListItem);
+    promiseList.push(promise);
+  });
+  const lastModifyTimeList = [];
+  console.log("loading job item lastModifyTime start");
+  Promise.allSettled(promiseList)
+    .then((textList) => {
+      console.log("loading job item lastModifyTime end");
+      textList.forEach((item) => {
+        const regxMatchArrayResult = item.value.match(
+          '<p class="gray">更新于：.*</p>'
+        );
+        if (regxMatchArrayResult && regxMatchArrayResult.length > 0) {
+          let date = regxMatchArrayResult[0]?.match(
+            /(\d{4}[-](\d{2})[-](\d{2}))/g
+          );
+          lastModifyTimeList.push(date);
+        } else {
+          lastModifyTimeList.push(null);
+        }
+      });
+      list.forEach((item, index) => {
+        item["lastModifyTime"] = lastModifyTimeList[index];
+      });
+      list.forEach((item) => {
+        const { itemId, lastModifyTime, brandName } = item;
+        const dom = getListItem(itemId);
+        let tag = createDOM(lastModifyTime, brandName);
+        dom.appendChild(tag);
+      });
+      renderSortJobItem(list, getListItem);
+    })
+    .catch((error) => {
+      console.log("loading job item lastModifyTime end");
+      console.log(error);
+      list.forEach((item) => {
+        const { itemId, lastModifyTime, brandName } = item;
+        const dom = getListItem(itemId);
+        let tag = createDOM(lastModifyTime, brandName);
+        dom.appendChild(tag);
+      });
+    });
 }
 
-function createDOM(lastModifyTime,brandName) {
-    const div = document.createElement('div');
-    div.classList.add('__boss_time_tag');
-    renderTimeTag(div,lastModifyTime,brandName);
-    return div;
+function isExistsLastModifyTime(text) {
+  const regxMatchArrayResult = text.match('<p class="gray">更新于：.*</p>');
+  return regxMatchArrayResult && regxMatchArrayResult.length > 0;
+}
+
+function createDOM(lastModifyTime, brandName) {
+  const div = document.createElement("div");
+  div.classList.add("__boss_time_tag");
+  renderTimeTag(div, lastModifyTime, brandName);
+  return div;
 }


### PR DESCRIPTION
CHANGELOG

1. 修復BOSS下獲取lastmodifytime的問題，當前邏輯是從工作詳情頁面獲取。
2. 新增BOOS下“正查找更新时间⌛︎”的加載提示。

**注意：測試請先登出BOSS賬號。**

Q/A：

1. 當前運行的效果可以顯示出來，但加載時間比較慢。
3. 運行原理是通過iframe進行頁面内容獲取。

顯示效果：

- BOSS直聘

_加載中_

![boss-show-time-merge-request-001-loading](https://github.com/tangzhiyao/boss-show-time/assets/5588354/53735ae3-ec09-452b-8486-aa0cfad8d641)

_加載完成_

![boss-show-time-merge-request-001](https://github.com/tangzhiyao/boss-show-time/assets/5588354/a2378bf5-13f2-4e57-89da-4e83f8164694)
